### PR TITLE
build: android support

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,11 +1,12 @@
 VPATH=%VPATH%
 
-UNAME=$(shell uname)
-
-ifeq ($(UNAME),Darwin)
+ifeq ($(CFG_OSTYPE),apple-darwin)
     OSTYPE=darwin
 endif
-ifeq ($(UNAME),Linux)
+ifeq ($(CFG_OSTYPE),unknown-linux-gnu)
+    OSTYPE=linux
+endif
+ifeq ($(CFG_OSTYPE),linux-androideabi)
     OSTYPE=linux
 endif
 
@@ -29,6 +30,9 @@ C_SRC= \
 
 C_OBJS = $(patsubst %.c,%.o,$(C_SRC))
 CFLAGS += -I$(VPATH)/src -Isrc/charset -I$(VPATH)/include -fPIC
+ifeq ($(CFG_TARGET_TRIPLE), arm-linux-androideabi)
+    CFLAGS += -DWITHOUT_ICONV_FILTER
+endif
 
 .PHONY: all
 all: libparserutils.dummy

--- a/configure
+++ b/configure
@@ -1,5 +1,4 @@
 #!/bin/bash
 
 SRCDIR="$(cd $(dirname $0) && pwd)"
-sed "s#%VPATH%#${SRCDIR}#" ${SRCDIR}/Makefile.in > Makefile
-
+sed -e "s#%VPATH%#${SRCDIR}#" ${SRCDIR}/Makefile.in > Makefile


### PR DESCRIPTION
android port preparation
1. additional submodule required for android
   fontconfig, libexpat, libfreetype2
2. It might need to update submodule and servo at once 
